### PR TITLE
feat: add optional max score limit to end game automatically

### DIFF
--- a/unocounter/__tests__/storage.test.ts
+++ b/unocounter/__tests__/storage.test.ts
@@ -385,4 +385,81 @@ describe("Storage Logic", () => {
       expect(updatedGame?.dealerId).toBe(initialDealerId);
     });
   });
+
+  describe("Max Score Limit Logic", () => {
+    test("createGame stores maxScore when specified", () => {
+      const game = createGame({
+        playerNames: ["Alice", "Bob"],
+        maxScore: 250,
+      });
+      expect(game.maxScore).toBe(250);
+    });
+
+    test("addRound keeps game active when player scores are below limit", () => {
+      const game = createGame({
+        playerNames: ["Alice", "Bob"],
+        maxScore: 100,
+      });
+
+      const updated = addRound(game.id, {
+        scores: [
+          { playerId: game.players[0].id, score: 40 },
+          { playerId: game.players[1].id, score: 50 },
+        ],
+      });
+
+      expect(updated?.isActive).toBe(true);
+      expect(updated?.players[0].totalScore).toBe(40);
+      expect(updated?.players[1].totalScore).toBe(50);
+    });
+
+    test("addRound terminates game when a player reaches or exceeds maxScore", () => {
+      const game = createGame({
+        playerNames: ["Alice", "Bob"],
+        maxScore: 100,
+      });
+
+      const updated = addRound(game.id, {
+        scores: [
+          { playerId: game.players[0].id, score: 100 },
+          { playerId: game.players[1].id, score: 20 },
+        ],
+      });
+
+      expect(updated?.isActive).toBe(false);
+      expect(updated?.players[0].totalScore).toBe(100);
+      expect(updated?.players[1].totalScore).toBe(20);
+    });
+
+    test("undoLastRound reactivates game if reverted scores are below maxScore", () => {
+      const game = createGame({
+        playerNames: ["Alice", "Bob"],
+        maxScore: 100,
+      });
+
+      // Round 1: below limit
+      let updated = addRound(game.id, {
+        scores: [
+          { playerId: game.players[0].id, score: 40 },
+          { playerId: game.players[1].id, score: 30 },
+        ],
+      });
+
+      // Round 2: exceeds limit
+      updated = addRound(game.id, {
+        scores: [
+          { playerId: game.players[0].id, score: 65 }, // total 105
+          { playerId: game.players[1].id, score: 20 }, // total 50
+        ],
+      });
+
+      expect(updated?.isActive).toBe(false);
+
+      // Undo Round 2
+      const reverted = undoLastRound(game.id);
+      expect(reverted?.isActive).toBe(true);
+      expect(reverted?.players[0].totalScore).toBe(40);
+      expect(reverted?.players[1].totalScore).toBe(30);
+    });
+  });
 });

--- a/unocounter/__tests__/storage.test.ts
+++ b/unocounter/__tests__/storage.test.ts
@@ -461,5 +461,31 @@ describe("Storage Logic", () => {
       expect(reverted?.players[0].totalScore).toBe(40);
       expect(reverted?.players[1].totalScore).toBe(30);
     });
+
+    test("addRound returns null and does not add round on inactive games", () => {
+      const game = createGame({
+        playerNames: ["Alice", "Bob"],
+        maxScore: 100,
+      });
+
+      // End the game by exceeding the limit
+      const endedGame = addRound(game.id, {
+        scores: [
+          { playerId: game.players[0].id, score: 120 },
+          { playerId: game.players[1].id, score: 10 },
+        ],
+      });
+      expect(endedGame?.isActive).toBe(false);
+      expect(endedGame?.rounds.length).toBe(1);
+
+      // Try adding another round
+      const result = addRound(game.id, {
+        scores: [
+          { playerId: game.players[0].id, score: 10 },
+          { playerId: game.players[1].id, score: 10 },
+        ],
+      });
+      expect(result).toBeNull();
+    });
   });
 });

--- a/unocounter/app/components/CreateGameForm.tsx
+++ b/unocounter/app/components/CreateGameForm.tsx
@@ -9,6 +9,8 @@ export default function CreateGameForm() {
   const router = useRouter();
   const [playerNames, setPlayerNames] = useState(["", ""]);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [hasLimit, setHasLimit] = useState(false);
+  const [maxScore, setMaxScore] = useState(500);
 
   const addPlayer = () => {
     setPlayerNames([...playerNames, ""]);
@@ -40,6 +42,7 @@ export default function CreateGameForm() {
     try {
       const newGame = createGame({
         playerNames: playerNames.map((name) => name.trim()),
+        maxScore: hasLimit ? maxScore : undefined,
       });
 
       router.push(`/games/${newGame.id}`);
@@ -96,6 +99,39 @@ export default function CreateGameForm() {
         >
           + Add Player
         </Button>
+
+        {/* Point Limit Option */}
+        <div className="border-t border-gray-200 pt-4">
+          <div className="flex items-center">
+            <input
+              id="set-limit"
+              type="checkbox"
+              checked={hasLimit}
+              onChange={(e) => setHasLimit(e.target.checked)}
+              className="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded"
+            />
+            <label htmlFor="set-limit" className="ml-2 block text-sm text-gray-900 font-medium">
+              Set maximum score limit
+            </label>
+          </div>
+
+          {hasLimit && (
+            <div className="mt-3">
+              <label htmlFor="max-score" className="block text-sm font-medium text-gray-700 mb-1">
+                Max Score Limit (Game ends when reached)
+              </label>
+              <input
+                id="max-score"
+                type="number"
+                min="1"
+                value={maxScore}
+                onChange={(e) => setMaxScore(Math.max(1, parseInt(e.target.value) || 0))}
+                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                required
+              />
+            </div>
+          )}
+        </div>
 
         <Button type="submit" disabled={isSubmitting} className="w-full">
           {isSubmitting ? "Creating Game..." : "Start Game"}

--- a/unocounter/app/components/CreateGameForm.tsx
+++ b/unocounter/app/components/CreateGameForm.tsx
@@ -10,7 +10,7 @@ export default function CreateGameForm() {
   const [playerNames, setPlayerNames] = useState(["", ""]);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [hasLimit, setHasLimit] = useState(false);
-  const [maxScore, setMaxScore] = useState(500);
+  const [maxScore, setMaxScore] = useState<number | "">(500);
 
   const addPlayer = () => {
     setPlayerNames([...playerNames, ""]);
@@ -40,9 +40,10 @@ export default function CreateGameForm() {
     await new Promise((resolve) => setTimeout(resolve, 500));
 
     try {
+      const parsedMaxScore = hasLimit ? (typeof maxScore === "number" && !Number.isNaN(maxScore) ? Math.max(1, maxScore) : 500) : undefined;
       const newGame = createGame({
         playerNames: playerNames.map((name) => name.trim()),
-        maxScore: hasLimit ? maxScore : undefined,
+        maxScore: parsedMaxScore,
       });
 
       router.push(`/games/${newGame.id}`);
@@ -125,7 +126,17 @@ export default function CreateGameForm() {
                 type="number"
                 min="1"
                 value={maxScore}
-                onChange={(e) => setMaxScore(Math.max(1, parseInt(e.target.value) || 0))}
+                onChange={(e) => {
+                  const val = e.target.value;
+                  setMaxScore(val === "" ? "" : parseInt(val, 10));
+                }}
+                onBlur={() => {
+                  if (maxScore === "" || Number.isNaN(maxScore)) {
+                    setMaxScore(500);
+                  } else {
+                    setMaxScore(Math.max(1, maxScore));
+                  }
+                }}
                 className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
                 required
               />

--- a/unocounter/app/games/[game]/page.tsx
+++ b/unocounter/app/games/[game]/page.tsx
@@ -197,7 +197,7 @@ export default function GamePage() {
           </div>
 
           <div className="grid grid-cols-2 gap-2 w-full md:w-auto md:flex md:gap-3">
-            {game.isActive && (
+            {game.isActive ? (
               <>
                 <Button
                   variant="secondary"
@@ -229,6 +229,16 @@ export default function GamePage() {
                   End Game
                 </Button>
               </>
+            ) : (
+              game.rounds.length > 0 && (
+                <Button
+                  variant="secondary"
+                  onClick={handleUndoLastRound}
+                  className="w-full md:w-auto"
+                >
+                  Undo Last Round (Resume Game)
+                </Button>
+              )
             )}
           </div>
         </div>
@@ -248,7 +258,7 @@ export default function GamePage() {
             </span>
           </div>
 
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-4 text-sm">
+          <div className="grid grid-cols-1 md:grid-cols-4 gap-4 text-sm">
             <div>
               <span className="text-gray-600">Current Turn:</span>
               <span className="ml-2 font-medium">{game.currentTurn}</span>
@@ -260,6 +270,12 @@ export default function GamePage() {
             <div>
               <span className="text-gray-600">Players:</span>
               <span className="ml-2 font-medium">{game.players.length}</span>
+            </div>
+            <div>
+              <span className="text-gray-600">Points Limit:</span>
+              <span className="ml-2 font-medium">
+                {game.maxScore !== undefined ? `${game.maxScore} pts` : "None"}
+              </span>
             </div>
           </div>
         </div>

--- a/unocounter/app/lib/storage.ts
+++ b/unocounter/app/lib/storage.ts
@@ -48,6 +48,11 @@ export const saveGames = (games: Game[]): void => {
 export const createGame = (data: CreateGameData): Game => {
   const games = getGames();
 
+  const normalizedMaxScore =
+    typeof data.maxScore === "number" && Number.isFinite(data.maxScore) && data.maxScore > 0
+      ? data.maxScore
+      : undefined;
+
   const newGame: Game = {
     id: generateId(),
     players: data.playerNames.map((name) => ({
@@ -61,7 +66,7 @@ export const createGame = (data: CreateGameData): Game => {
     createdAt: new Date(),
     updatedAt: new Date(),
     isActive: true,
-    maxScore: data.maxScore,
+    maxScore: normalizedMaxScore,
   };
 
   if (newGame.players.length > 0) {
@@ -125,6 +130,7 @@ export const addRound = (gameId: string, data: AddRoundData): Game | null => {
   if (gameIndex === -1) return null;
 
   const game = games[gameIndex];
+  if (!game.isActive) return null;
   const newRound = {
     turnNumber: game.currentTurn,
     scores: data.scores,

--- a/unocounter/app/lib/storage.ts
+++ b/unocounter/app/lib/storage.ts
@@ -61,6 +61,7 @@ export const createGame = (data: CreateGameData): Game => {
     createdAt: new Date(),
     updatedAt: new Date(),
     isActive: true,
+    maxScore: data.maxScore,
   };
 
   if (newGame.players.length > 0) {
@@ -153,12 +154,16 @@ export const addRound = (gameId: string, data: AddRoundData): Game | null => {
     }
   }
 
+  const hasReachedMaxScore = game.maxScore !== undefined &&
+    updatedPlayers.some((player) => player.totalScore >= (game.maxScore as number));
+
   const updatedGame: Game = {
     ...game,
     players: updatedPlayers,
     currentTurn: game.currentTurn + 1,
     dealerId: nextDealerId,
     rounds: [...game.rounds, newRound],
+    isActive: hasReachedMaxScore ? false : game.isActive,
     updatedAt: new Date(),
   };
 
@@ -200,12 +205,16 @@ export const undoLastRound = (gameId: string): Game | null => {
     }
   }
 
+  const hasReachedMaxScoreAfterUndo = game.maxScore !== undefined &&
+    updatedPlayers.some((player) => player.totalScore >= (game.maxScore as number));
+
   const updatedGame: Game = {
     ...game,
     players: updatedPlayers,
     currentTurn: Math.max(1, game.currentTurn - 1),
     dealerId: previousDealerId,
     rounds: game.rounds.slice(0, -1),
+    isActive: hasReachedMaxScoreAfterUndo ? false : true,
     updatedAt: new Date(),
   };
 

--- a/unocounter/app/types/game.ts
+++ b/unocounter/app/types/game.ts
@@ -19,10 +19,12 @@ export interface Game {
   createdAt: Date;
   updatedAt: Date;
   isActive: boolean;
+  maxScore?: number;
 }
 
 export interface CreateGameData {
   playerNames: string[];
+  maxScore?: number;
 }
 
 export interface AddRoundData {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional points limit when creating a game.
  * The game view now shows the configured points limit and updates controls based on whether a game is active.

* **Bug Fixes**
  * Games now end automatically when a player reaches the limit.
  * Undoing the last round can resume a game if totals drop back below the limit.

* **Tests**
  * Added coverage for points-limit behavior during game creation, round entry, and undo actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->