### PR TITLE
feat: add interactive score progression chart

### DIFF
--- a/unocounter/__tests__/components/ScoreChart.test.tsx
+++ b/unocounter/__tests__/components/ScoreChart.test.tsx
@@ -82,6 +82,38 @@ const mockGameWithMidGamePlayer: Game = {
   ],
 };
 
+const mockGameWithNewMidGamePlayerNotPlayed: Game = {
+  id: "game-123",
+  players: [
+    { id: "p1", name: "Alice", totalScore: 25 },
+    { id: "p2", name: "Bob", totalScore: 35 },
+    { id: "p3", name: "Charlie", totalScore: 50 }, // Added just now, hasn't played any rounds yet
+  ],
+  createdAt: new Date("2023-01-01T12:00:00"),
+  updatedAt: new Date("2023-01-01T13:00:00"),
+  currentTurn: 3,
+  isActive: true,
+  dealerId: "p1",
+  rounds: [
+    {
+      turnNumber: 1,
+      timestamp: new Date("2023-01-01T12:10:00"),
+      scores: [
+        { playerId: "p1", score: 10 },
+        { playerId: "p2", score: 20 },
+      ],
+    },
+    {
+      turnNumber: 2,
+      timestamp: new Date("2023-01-01T12:20:00"),
+      scores: [
+        { playerId: "p1", score: 15 },
+        { playerId: "p2", score: 15 },
+      ],
+    },
+  ],
+};
+
 describe("ScoreChart Component", () => {
   test("renders empty state placeholder when no rounds are played", () => {
     render(<ScoreChart game={mockGameNoRounds} />);
@@ -204,5 +236,45 @@ describe("ScoreChart Component", () => {
     // Move mouse out
     fireEvent.mouseLeave(svg);
     expect(screen.queryByTestId("chart-tooltip")).not.toBeInTheDocument();
+  });
+
+  test("handles player added mid-game who hasn't played any rounds yet", () => {
+    render(<ScoreChart game={mockGameWithNewMidGamePlayerNotPlayed} />);
+
+    // Legend should contain Charlie
+    expect(screen.getByTestId("chart-legend")).toHaveTextContent("Charlie");
+
+    const svg = screen.getByTestId("score-progression-svg");
+    svg.getBoundingClientRect = jest.fn(() => ({
+      width: 600,
+      height: 350,
+      top: 0,
+      left: 0,
+      bottom: 350,
+      right: 600,
+      x: 0,
+      y: 0,
+      toJSON: () => {},
+    }));
+
+    // Hover over Round 1 (center: X = 310)
+    fireEvent.mouseMove(svg, { clientX: 310, clientY: 175 });
+    
+    // Charlie should NOT be in the tooltip for Round 1
+    let tooltip = screen.getByTestId("chart-tooltip");
+    expect(tooltip).toHaveTextContent("Round 1");
+    expect(tooltip).toHaveTextContent("Alice");
+    expect(tooltip).toHaveTextContent("Bob");
+    expect(tooltip).not.toHaveTextContent("Charlie");
+
+    // Hover over Round 2 (end: X = 570)
+    // plotWidth = 520, paddingLeft = 50. getX(2) = 50 + 520 = 570
+    fireEvent.mouseMove(svg, { clientX: 570, clientY: 175 });
+
+    // Charlie SHOULD be in the tooltip for Round 2 (with score 50)
+    tooltip = screen.getByTestId("chart-tooltip");
+    expect(tooltip).toHaveTextContent("Round 2");
+    expect(tooltip).toHaveTextContent("Charlie");
+    expect(tooltip).toHaveTextContent("50");
   });
 });

--- a/unocounter/__tests__/components/ScoreChart.test.tsx
+++ b/unocounter/__tests__/components/ScoreChart.test.tsx
@@ -1,0 +1,208 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import ScoreChart from "../../app/components/ScoreChart";
+import { Game } from "../../app/types/game";
+
+const mockGameNoRounds: Game = {
+  id: "game-123",
+  players: [
+    { id: "p1", name: "Alice", totalScore: 0 },
+    { id: "p2", name: "Bob", totalScore: 0 },
+  ],
+  createdAt: new Date("2023-01-01T12:00:00"),
+  updatedAt: new Date("2023-01-01T13:00:00"),
+  currentTurn: 1,
+  isActive: true,
+  dealerId: "p1",
+  rounds: [],
+};
+
+const mockGameWithRounds: Game = {
+  id: "game-123",
+  players: [
+    { id: "p1", name: "Alice", totalScore: 25 }, // starts at 0, round 1: +10, round 2: +15 = 25
+    { id: "p2", name: "Bob", totalScore: 35 },   // starts at 0, round 1: +20, round 2: +15 = 35
+  ],
+  createdAt: new Date("2023-01-01T12:00:00"),
+  updatedAt: new Date("2023-01-01T13:00:00"),
+  currentTurn: 3,
+  isActive: true,
+  dealerId: "p1",
+  rounds: [
+    {
+      turnNumber: 1,
+      timestamp: new Date("2023-01-01T12:10:00"),
+      scores: [
+        { playerId: "p1", score: 10 },
+        { playerId: "p2", score: 20 },
+      ],
+    },
+    {
+      turnNumber: 2,
+      timestamp: new Date("2023-01-01T12:20:00"),
+      scores: [
+        { playerId: "p1", score: 15 },
+        { playerId: "p2", score: 15 },
+      ],
+    },
+  ],
+};
+
+const mockGameWithMidGamePlayer: Game = {
+  id: "game-123",
+  players: [
+    { id: "p1", name: "Alice", totalScore: 25 }, // starts at 0, R1: 10, R2: 15
+    { id: "p2", name: "Bob", totalScore: 35 },   // starts at 0, R1: 20, R2: 15
+    { id: "p3", name: "Charlie", totalScore: 40 }, // joined before R2 with start score 30, R2: 10
+  ],
+  createdAt: new Date("2023-01-01T12:00:00"),
+  updatedAt: new Date("2023-01-01T13:00:00"),
+  currentTurn: 3,
+  isActive: true,
+  dealerId: "p1",
+  rounds: [
+    {
+      turnNumber: 1,
+      timestamp: new Date("2023-01-01T12:10:00"),
+      scores: [
+        { playerId: "p1", score: 10 },
+        { playerId: "p2", score: 20 },
+      ],
+    },
+    {
+      turnNumber: 2,
+      timestamp: new Date("2023-01-01T12:20:00"),
+      scores: [
+        { playerId: "p1", score: 15 },
+        { playerId: "p2", score: 15 },
+        { playerId: "p3", score: 10 },
+      ],
+    },
+  ],
+};
+
+describe("ScoreChart Component", () => {
+  test("renders empty state placeholder when no rounds are played", () => {
+    render(<ScoreChart game={mockGameNoRounds} />);
+
+    expect(screen.getByText(/Play at least one round/i)).toBeInTheDocument();
+    expect(screen.queryByTestId("score-progression-svg")).not.toBeInTheDocument();
+  });
+
+  test("renders legend and SVG canvas when rounds are played", () => {
+    render(<ScoreChart game={mockGameWithRounds} />);
+
+    expect(screen.getByText(/Score Progression Chart/i)).toBeInTheDocument();
+    expect(screen.getByTestId("score-progression-svg")).toBeInTheDocument();
+    
+    // Check legend items
+    const legend = screen.getByTestId("chart-legend");
+    expect(legend).toHaveTextContent("Alice");
+    expect(legend).toHaveTextContent("Bob");
+  });
+
+  test("renders player lines and data points", () => {
+    render(<ScoreChart game={mockGameWithRounds} />);
+
+    // Check SVG paths
+    const alicePath = screen.getByTestId("player-line-p1");
+    const bobPath = screen.getByTestId("player-line-p2");
+
+    expect(alicePath).toBeInTheDocument();
+    expect(bobPath).toBeInTheDocument();
+
+    expect(alicePath).toHaveAttribute("stroke");
+    expect(bobPath).toHaveAttribute("stroke");
+
+    // Check data points group
+    expect(screen.getByTestId("player-dots-p1")).toBeInTheDocument();
+    expect(screen.getByTestId("player-dots-p2")).toBeInTheDocument();
+  });
+
+  test("toggles player line visibility when legend is clicked", () => {
+    render(<ScoreChart game={mockGameWithRounds} />);
+
+    const aliceLegendBtn = screen.getByRole("button", { name: /Alice/i });
+    const bobLegendBtn = screen.getByRole("button", { name: /Bob/i });
+
+    // Both lines visible initially
+    expect(screen.getByTestId("player-line-p1")).toBeInTheDocument();
+    expect(screen.getByTestId("player-line-p2")).toBeInTheDocument();
+
+    // Click Alice legend to hide
+    fireEvent.click(aliceLegendBtn);
+    expect(screen.queryByTestId("player-line-p1")).not.toBeInTheDocument();
+    expect(screen.getByTestId("player-line-p2")).toBeInTheDocument();
+
+    // Click Bob legend to hide too
+    fireEvent.click(bobLegendBtn);
+    expect(screen.queryByTestId("player-line-p1")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("player-line-p2")).not.toBeInTheDocument();
+    expect(screen.getByText(/Select at least one player/i)).toBeInTheDocument();
+
+    // Click Alice legend to show again
+    fireEvent.click(aliceLegendBtn);
+    expect(screen.getByTestId("player-line-p1")).toBeInTheDocument();
+    expect(screen.queryByTestId("player-line-p2")).not.toBeInTheDocument();
+  });
+
+  test("handles player added mid-game correctly", () => {
+    render(<ScoreChart game={mockGameWithMidGamePlayer} />);
+
+    // All player lines should render
+    expect(screen.getByTestId("player-line-p1")).toBeInTheDocument();
+    expect(screen.getByTestId("player-line-p2")).toBeInTheDocument();
+    expect(screen.getByTestId("player-line-p3")).toBeInTheDocument();
+    
+    // Check legend has Charlie
+    expect(screen.getByTestId("chart-legend")).toHaveTextContent("Charlie");
+  });
+
+  test("shows and hides tooltip on mouse interaction", () => {
+    render(<ScoreChart game={mockGameWithRounds} />);
+
+    const svg = screen.getByTestId("score-progression-svg");
+    
+    // Tooltip should not be visible initially
+    expect(screen.queryByTestId("chart-tooltip")).not.toBeInTheDocument();
+
+    // Mock getBoundingClientRect for SVG to make coordinates math work
+    svg.getBoundingClientRect = jest.fn(() => ({
+      width: 600,
+      height: 350,
+      top: 0,
+      left: 0,
+      bottom: 350,
+      right: 600,
+      x: 0,
+      y: 0,
+      toJSON: () => {},
+    }));
+
+    // Hover over the center of the chart
+    // plotWidth = 600 - 50 - 30 = 520. paddingLeft = 50.
+    // N = 2.
+    // X = 50 + (1 / 2) * 520 = 310 (represents Round 1)
+    fireEvent.mouseMove(svg, {
+      clientX: 310,
+      clientY: 175,
+    });
+
+    // Tooltip should now be visible
+    const tooltip = screen.getByTestId("chart-tooltip");
+    expect(tooltip).toBeInTheDocument();
+    expect(tooltip).toHaveTextContent("Round 1");
+    expect(tooltip).toHaveTextContent("Alice");
+    expect(tooltip).toHaveTextContent("Bob");
+    
+    // Check Alice score at round 1: 10 (+10)
+    expect(tooltip).toHaveTextContent("10");
+    // Check Bob score at round 1: 20 (+20)
+    expect(tooltip).toHaveTextContent("20");
+
+    // Move mouse out
+    fireEvent.mouseLeave(svg);
+    expect(screen.queryByTestId("chart-tooltip")).not.toBeInTheDocument();
+  });
+});

--- a/unocounter/__tests__/games/[game]/page.test.tsx
+++ b/unocounter/__tests__/games/[game]/page.test.tsx
@@ -286,7 +286,7 @@ describe("GamePage", () => {
     render(<GamePage />);
 
     await waitFor(() => {
-      expect(screen.getByText("Alice")).toBeInTheDocument();
+      expect(screen.getAllByText("Alice")[0]).toBeInTheDocument();
     });
 
     // Undo button should be enabled

--- a/unocounter/app/components/ScoreChart.tsx
+++ b/unocounter/app/components/ScoreChart.tsx
@@ -75,7 +75,7 @@ export default function ScoreChart({ game }: ScoreChartProps) {
     const firstActiveRoundIndex = game.rounds.findIndex((round) =>
       round.scores.some((s) => s.playerId === player.id)
     );
-    const activeStart = firstActiveRoundIndex === -1 ? 0 : firstActiveRoundIndex;
+    const activeStart = firstActiveRoundIndex === -1 ? N : firstActiveRoundIndex;
 
     // 4. Fill history array: [0..N]
     const scores: (number | undefined)[] = new Array(N + 1).fill(undefined);

--- a/unocounter/app/components/ScoreChart.tsx
+++ b/unocounter/app/components/ScoreChart.tsx
@@ -1,0 +1,472 @@
+"use client";
+
+import React, { useState, useRef } from "react";
+import { Game, Player } from "../types/game";
+
+interface ScoreChartProps {
+  game: Game;
+}
+
+const PLAYER_COLORS = [
+  "#3B82F6", // Blue
+  "#10B981", // Emerald Green
+  "#EF4444", // Red
+  "#F59E0B", // Amber/Yellow
+  "#8B5CF6", // Violet/Purple
+  "#EC4899", // Pink
+  "#14B8A6", // Teal
+  "#6366F1", // Indigo
+];
+
+export default function ScoreChart({ game }: ScoreChartProps) {
+  const [hiddenPlayerIds, setHiddenPlayerIds] = useState<string[]>([]);
+  const [hoveredPlayerId, setHoveredPlayerId] = useState<string | null>(null);
+  const [hoveredRound, setHoveredRound] = useState<number | null>(null);
+  const [tooltip, setTooltip] = useState<{
+    visible: boolean;
+    round: number;
+    x: number;
+    y: number;
+  }>({
+    visible: false,
+    round: 0,
+    x: 0,
+    y: 0,
+  });
+
+  const containerRef = useRef<HTMLDivElement>(null);
+  const svgRef = useRef<SVGSVGElement>(null);
+
+  const N = game.rounds.length;
+
+  // We need at least one round to display a progression line chart (Round 0 to Round N)
+  if (N === 0) {
+    return (
+      <div className="bg-white rounded-lg shadow-md p-6 mb-8 text-center py-12">
+        <h2 className="text-xl font-semibold text-gray-900 mb-2">Score Progression Chart</h2>
+        <p className="text-gray-500">Play at least one round to see the progression chart.</p>
+      </div>
+    );
+  }
+
+  // Get color for player based on their index in the original list
+  const getPlayerColor = (playerId: string) => {
+    const idx = game.players.findIndex((p) => p.id === playerId);
+    return PLAYER_COLORS[idx % PLAYER_COLORS.length];
+  };
+
+  // Reconstruct score history for all players
+  const playerProgressions = game.players.map((player) => {
+    // 1. Calculate sum of scores in all recorded rounds
+    const roundScores = game.rounds.map((round) => {
+      const match = round.scores.find((s) => s.playerId === player.id);
+      return match ? match.score : undefined;
+    });
+
+    const sumOfRoundScores = roundScores.reduce<number>(
+      (sum, score) => sum + (score || 0),
+      0
+    );
+
+    // 2. Derive starting score: totalScore = startingScore + sumOfRoundScores
+    const startingScore = player.totalScore - sumOfRoundScores;
+
+    // 3. Find first round index where player has a recorded score
+    const firstActiveRoundIndex = game.rounds.findIndex((round) =>
+      round.scores.some((s) => s.playerId === player.id)
+    );
+    const activeStart = firstActiveRoundIndex === -1 ? 0 : firstActiveRoundIndex;
+
+    // 4. Fill history array: [0..N]
+    const scores: (number | undefined)[] = new Array(N + 1).fill(undefined);
+    scores[activeStart] = startingScore;
+
+    for (let r = activeStart + 1; r <= N; r++) {
+      const roundScore =
+        game.rounds[r - 1].scores.find((s) => s.playerId === player.id)?.score || 0;
+      scores[r] = (scores[r - 1] as number) + roundScore;
+    }
+
+    return {
+      player,
+      scores,
+      activeStart,
+      color: getPlayerColor(player.id),
+    };
+  });
+
+  // Filter based on active (visible) players
+  const visibleProgressions = playerProgressions.filter(
+    (p) => !hiddenPlayerIds.includes(p.player.id)
+  );
+
+  // Find min/max scores for visible lines to scale Y-axis
+  let allVisibleScores: number[] = [];
+  visibleProgressions.forEach((p) => {
+    p.scores.forEach((score) => {
+      if (score !== undefined) {
+        allVisibleScores.push(score);
+      }
+    });
+  });
+
+  if (allVisibleScores.length === 0) {
+    allVisibleScores = [0, 100];
+  }
+
+  const rawMin = Math.min(...allVisibleScores);
+  const rawMax = Math.max(...allVisibleScores);
+  const range = rawMax - rawMin;
+  const paddingPercent = range === 0 ? 20 : Math.ceil(range * 0.1);
+  const yMinVal = rawMin < 0 ? rawMin - paddingPercent : Math.max(0, rawMin - paddingPercent);
+  const yMaxVal = rawMax + paddingPercent;
+
+  // ViewBox layout details
+  const viewBoxWidth = 600;
+  const viewBoxHeight = 350;
+  const paddingTop = 30;
+  const paddingRight = 30;
+  const paddingBottom = 40;
+  const paddingLeft = 50;
+
+  const plotWidth = viewBoxWidth - paddingLeft - paddingRight;
+  const plotHeight = viewBoxHeight - paddingTop - paddingBottom;
+
+  // Coordinate mapping functions
+  const getX = (r: number) => paddingLeft + (r / N) * plotWidth;
+  const getY = (val: number) => {
+    if (yMaxVal === yMinVal) return paddingTop + plotHeight / 2;
+    return viewBoxHeight - paddingBottom - ((val - yMinVal) / (yMaxVal - yMinVal)) * plotHeight;
+  };
+
+  // Generate unique grid line values
+  const gridLines = Array.from(
+    new Set(
+      Array.from({ length: 5 }, (_, i) => {
+        const val = yMinVal + (i / 4) * (yMaxVal - yMinVal);
+        return Math.round(val);
+      })
+    )
+  ).sort((a, b) => a - b);
+
+  // Legend toggle handlers
+  const togglePlayerVisibility = (playerId: string) => {
+    setHiddenPlayerIds((prev) =>
+      prev.includes(playerId)
+        ? prev.filter((id) => id !== playerId)
+        : [...prev, playerId]
+    );
+  };
+
+  // Mouse interactivity handlers
+  const handleMouseMove = (e: React.MouseEvent<SVGSVGElement>) => {
+    if (!containerRef.current || !svgRef.current) return;
+    const rect = svgRef.current.getBoundingClientRect();
+    const mouseX = e.clientX - rect.left;
+    const mouseY = e.clientY - rect.top;
+
+    // Map mouseX back to viewBox coordinate system
+    const relativeX = (mouseX / rect.width) * viewBoxWidth;
+
+    // Calculate nearest round
+    const r = Math.round(((relativeX - paddingLeft) / plotWidth) * N);
+    const clampedRound = Math.max(0, Math.min(N, r));
+
+    // Get position in container coordinates for HTML Tooltip positioning
+    const containerRect = containerRef.current.getBoundingClientRect();
+    const tooltipX = e.clientX - containerRect.left;
+    const tooltipY = e.clientY - containerRect.top;
+
+    setHoveredRound(clampedRound);
+    setTooltip({
+      visible: true,
+      round: clampedRound,
+      x: tooltipX,
+      y: tooltipY,
+    });
+  };
+
+  const handleMouseLeave = () => {
+    setHoveredRound(null);
+    setTooltip((prev) => ({ ...prev, visible: false }));
+  };
+
+  // Prepare data for the tooltip leaderboard list
+  const getTooltipData = () => {
+    if (hoveredRound === null) return [];
+    
+    return playerProgressions
+      .map((prog) => {
+        const score = prog.scores[hoveredRound];
+        // Calculate points gained in this round
+        let roundDiff = 0;
+        if (hoveredRound > 0 && score !== undefined) {
+          const prevScore = prog.scores[hoveredRound - 1];
+          if (prevScore !== undefined) {
+            roundDiff = score - prevScore;
+          } else {
+            // Joined this round
+            roundDiff = score - (prog.scores[prog.activeStart] || 0);
+          }
+        }
+        return {
+          player: prog.player,
+          score,
+          diff: roundDiff,
+          color: prog.color,
+          visible: !hiddenPlayerIds.includes(prog.player.id),
+        };
+      })
+      .filter((p) => p.score !== undefined) // Only show active players at this round
+      .sort((a, b) => (b.score as number) - (a.score as number));
+  };
+
+  // SVG drawing logic for player lines
+  const drawLinePath = (scores: (number | undefined)[]) => {
+    let path = "";
+    let isDrawing = false;
+
+    scores.forEach((score, r) => {
+      if (score !== undefined) {
+        const x = getX(r);
+        const y = getY(score);
+        if (!isDrawing) {
+          path += `M ${x} ${y}`;
+          isDrawing = true;
+        } else {
+          path += ` L ${x} ${y}`;
+        }
+      }
+    });
+
+    return path;
+  };
+
+  const tooltipData = getTooltipData();
+  const labelInterval = N > 12 ? Math.ceil(N / 6) : 1;
+
+  return (
+    <div
+      ref={containerRef}
+      className="bg-white rounded-lg shadow-md p-6 mb-8 relative select-none"
+    >
+      <h2 className="text-xl font-semibold text-gray-900 mb-4">Score Progression Chart</h2>
+
+      {/* Legend */}
+      <div className="flex flex-wrap gap-3 mb-6" data-testid="chart-legend">
+        {playerProgressions.map((prog) => {
+          const isHidden = hiddenPlayerIds.includes(prog.player.id);
+          const isDimmed =
+            hoveredPlayerId !== null && hoveredPlayerId !== prog.player.id;
+
+          return (
+            <button
+              key={prog.player.id}
+              onClick={() => togglePlayerVisibility(prog.player.id)}
+              onMouseEnter={() => setHoveredPlayerId(prog.player.id)}
+              onMouseLeave={() => setHoveredPlayerId(null)}
+              className={`flex items-center gap-2 px-3 py-1 rounded-full text-xs font-medium border transition-all cursor-pointer ${
+                isHidden
+                  ? "bg-gray-50 text-gray-400 border-gray-200 line-through"
+                  : "bg-white border-gray-300 text-gray-700"
+              } ${isDimmed ? "opacity-40" : "opacity-100"}`}
+              style={{
+                borderColor: isHidden ? undefined : prog.color,
+                boxShadow: isHidden
+                  ? undefined
+                  : `0 1px 2px 0 ${prog.color}15`,
+              }}
+            >
+              <span
+                className="w-2.5 h-2.5 rounded-full"
+                style={{
+                  backgroundColor: isHidden ? "#9CA3AF" : prog.color,
+                }}
+              />
+              <span>{prog.player.name}</span>
+            </button>
+          );
+        })}
+      </div>
+
+      {visibleProgressions.length === 0 ? (
+        <div className="flex flex-col items-center justify-center h-64 border border-dashed border-gray-200 rounded-lg">
+          <p className="text-gray-500 text-sm">Select at least one player in the legend to display the chart.</p>
+        </div>
+      ) : (
+        <div className="relative">
+          <svg
+            ref={svgRef}
+            viewBox={`0 0 ${viewBoxWidth} ${viewBoxHeight}`}
+            width="100%"
+            height="auto"
+            className="overflow-visible animate-fade-in"
+            onMouseMove={handleMouseMove}
+            onMouseLeave={handleMouseLeave}
+            data-testid="score-progression-svg"
+          >
+            {/* Horizontal Grid Lines */}
+            <g className="grid-lines">
+              {gridLines.map((val) => (
+                <g key={val}>
+                  <line
+                    x1={paddingLeft}
+                    y1={getY(val)}
+                    x2={viewBoxWidth - paddingRight}
+                    y2={getY(val)}
+                    stroke="#F3F4F6"
+                    strokeWidth="1"
+                    strokeDasharray="4 4"
+                  />
+                  <text
+                    x={paddingLeft - 10}
+                    y={getY(val) + 4}
+                    textAnchor="end"
+                    className="text-[10px] fill-gray-400 font-medium font-sans"
+                  >
+                    {val}
+                  </text>
+                </g>
+              ))}
+            </g>
+
+            {/* X-axis Labels */}
+            <g className="x-axis-labels">
+              {Array.from({ length: N + 1 }).map((_, r) => {
+                if (r % labelInterval !== 0) return null;
+                const label = r === 0 ? "Start" : `R${r}`;
+                return (
+                  <text
+                    key={r}
+                    x={getX(r)}
+                    y={viewBoxHeight - paddingBottom + 18}
+                    textAnchor="middle"
+                    className="text-[10px] fill-gray-400 font-medium font-sans"
+                  >
+                    {label}
+                  </text>
+                );
+              })}
+            </g>
+
+            {/* Vertical Cursor Line */}
+            {hoveredRound !== null && (
+              <line
+                x1={getX(hoveredRound)}
+                y1={paddingTop}
+                x2={getX(hoveredRound)}
+                y2={viewBoxHeight - paddingBottom}
+                stroke="#9CA3AF"
+                strokeWidth="1.5"
+                strokeDasharray="3 3"
+                className="pointer-events-none"
+              />
+            )}
+
+            {/* Player Lines */}
+            {visibleProgressions.map((prog) => {
+              const isHovered = hoveredPlayerId === prog.player.id;
+              const isAnyHovered = hoveredPlayerId !== null;
+              const opacity = isHovered ? 1 : isAnyHovered ? 0.15 : 0.85;
+              const strokeWidth = isHovered ? 3.5 : 2;
+
+              return (
+                <path
+                  key={prog.player.id}
+                  d={drawLinePath(prog.scores)}
+                  fill="none"
+                  stroke={prog.color}
+                  strokeWidth={strokeWidth}
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  style={{ opacity, transition: "stroke-width 0.2s, opacity 0.2s" }}
+                  data-testid={`player-line-${prog.player.id}`}
+                />
+              );
+            })}
+
+            {/* Data Points */}
+            {visibleProgressions.map((prog) => {
+              const isHovered = hoveredPlayerId === prog.player.id;
+              const isAnyHovered = hoveredPlayerId !== null;
+              const opacity = isHovered ? 1 : isAnyHovered ? 0.15 : 0.9;
+
+              return (
+                <g
+                  key={prog.player.id}
+                  style={{ opacity, transition: "opacity 0.2s" }}
+                  data-testid={`player-dots-${prog.player.id}`}
+                >
+                  {prog.scores.map((score, r) => {
+                    if (score === undefined) return null;
+                    const isDotHovered = hoveredRound === r;
+
+                    return (
+                      <circle
+                        key={r}
+                        cx={getX(r)}
+                        cy={getY(score)}
+                        r={isDotHovered ? 5 : 3.5}
+                        fill="#FFFFFF"
+                        stroke={prog.color}
+                        strokeWidth={isDotHovered ? 2.5 : 1.5}
+                        className="transition-all duration-150 ease-out cursor-pointer"
+                        onMouseEnter={() => setHoveredPlayerId(prog.player.id)}
+                        onMouseLeave={() => setHoveredPlayerId(null)}
+                      />
+                    );
+                  })}
+                </g>
+              );
+            })}
+          </svg>
+
+          {/* Hover Tooltip (HTML overlay) */}
+          {tooltip.visible && hoveredRound !== null && (
+            <div
+              className="absolute pointer-events-none bg-white/90 backdrop-blur-md border border-gray-200 shadow-xl rounded-xl p-3 z-30 flex flex-col gap-2 min-w-44 text-xs font-sans transition-all duration-75"
+              style={{
+                left: `${tooltip.x + 15}px`,
+                top: `${tooltip.y - 40}px`,
+                transform: `translateY(-50%)`,
+              }}
+              data-testid="chart-tooltip"
+            >
+              <div className="font-semibold text-gray-900 border-b border-gray-100 pb-1 mb-1">
+                {tooltip.round === 0 ? "Start of Game" : `Round ${tooltip.round}`}
+              </div>
+              <div className="flex flex-col gap-1.5">
+                {tooltipData.map((item) => (
+                  <div
+                    key={item.player.id}
+                    className={`flex items-center justify-between gap-4 ${
+                      item.visible ? "opacity-100" : "opacity-40"
+                    }`}
+                  >
+                    <div className="flex items-center gap-1.5">
+                      <span
+                        className="w-2 h-2 rounded-full inline-block"
+                        style={{ backgroundColor: item.color }}
+                      />
+                      <span className="font-medium text-gray-700">
+                        {item.player.name}
+                      </span>
+                    </div>
+                    <div className="flex items-center gap-1 font-semibold text-gray-900">
+                      <span>{item.score}</span>
+                      {tooltip.round > 0 && item.diff !== 0 && (
+                        <span className="text-[10px] font-normal text-gray-400">
+                          ({item.diff > 0 ? `+${item.diff}` : item.diff})
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/unocounter/app/games/[game]/page.tsx
+++ b/unocounter/app/games/[game]/page.tsx
@@ -5,6 +5,7 @@ import { useParams, useRouter } from "next/navigation";
 import Link from "next/link";
 import Button from "../../components/Button";
 import Calculator from "../../components/Calculator";
+import ScoreChart from "../../components/ScoreChart";
 import { Game } from "../../types/game";
 import {
   getGame,
@@ -398,6 +399,9 @@ export default function GamePage() {
             ))}
           </div>
         </div>
+
+        {/* Score Progression Chart */}
+        <ScoreChart game={game} />
 
         {/* Round History */}
         {game.rounds.length > 0 && (


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a score progression chart to game pages, showing how player scores change round by round.
  * The chart includes hover tooltips, a round cursor, and legend controls to show or hide players.
  * When no rounds are available, users now see a clear empty-state message instead of a blank chart.

* **Tests**
  * Added coverage for chart rendering, hover behavior, legend interactions, empty states, and players joining mid-game.
  * Updated an existing game-page test to handle repeated player names correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->